### PR TITLE
상세 화면 코인 과거 데이터 못 불러오는 버그 수정

### DIFF
--- a/Huhoe/Huhoe/Presentation/Scene/HuhoeDetail/View/HuhoeDetailViewController.swift
+++ b/Huhoe/Huhoe/Presentation/Scene/HuhoeDetail/View/HuhoeDetailViewController.swift
@@ -159,9 +159,8 @@ extension HuhoeDetailViewController {
             })
             .disposed(by: disposeBag)
         
-        Observable.combineLatest(output.currentCoinHistoryInformation, output.pastCoinHistoryInformation)
+        Observable.zip(output.currentCoinHistoryInformation, output.pastCoinHistoryInformation)
             .observe(on: MainScheduler.asyncInstance)
-            .take(1)
             .subscribe(onNext: { [weak self] current, past in
                 self?.applySnapShot(current, past)
             })


### PR DESCRIPTION
상세 화면 진입시 DetailVC의 take1으로 인해 한번만 데이터를 불러오고 그 뒤로는 못불러오는(실시간 매수가 없을시) 버그 수정